### PR TITLE
Fix GitHub Pages deployment CI error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v4
+        with:
+          enablement: true
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/emirmensitov-afk/-/issues/3
+Your prepared branch: issue-3-c52659be06f8
+Your prepared working directory: /tmp/gh-issue-solver-1764603841992
+Your forked repository: konard/emirmensitov-afk--
+Original repository (upstream): emirmensitov-afk/-
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/emirmensitov-afk/-/issues/3
-Your prepared branch: issue-3-c52659be06f8
-Your prepared working directory: /tmp/gh-issue-solver-1764603841992
-Your forked repository: konard/emirmensitov-afk--
-Original repository (upstream): emirmensitov-afk/-
-
-Proceed.


### PR DESCRIPTION
## Summary

- Fix GitHub Pages deployment workflow by adding `enablement: true` to `actions/configure-pages@v4`

## Problem

The CI was failing with the following error:
```
Get Pages site failed. Please verify that the repository has Pages enabled and configured to build using GitHub Actions, or consider exploring the `enablement` parameter for this action.
```

## Solution

Added the `enablement: true` parameter to the `actions/configure-pages@v4` action. This parameter tells the action to automatically enable GitHub Pages on the repository if it's not already configured.

### Changes made:
```yaml
- name: Setup Pages
  uses: actions/configure-pages@v4
  with:
    enablement: true
```

## Test plan

- [x] Local lint check passes (`npm run lint`)
- [x] Local build passes (`npm run build`)
- [ ] Verify CI workflow passes after merge to main

## References

- Issue: #3
- Failed CI run: https://github.com/emirmensitov-afk/-/actions/runs/19467795061/job/55706899560

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Fixes emirmensitov-afk/-#3